### PR TITLE
Fjerner referanse til pixabay

### DIFF
--- a/bruk-av-lisenser.html
+++ b/bruk-av-lisenser.html
@@ -173,7 +173,7 @@
                         <div class="col-heading">CC0 eller public domain dedication</div>
                         <div class="col-subheading">CC0 betyr Opphavspersonen har selv gitt verket til fellesskapet og frasier seg alle rettigheter, også navngivelse.</div>
                         <p>I Norge brukes dette ikke, siden åndsverksloven krever navngivelse og opphavsrett uavhengig av om opphavspersonen selv ønsker det eller ikke. Når vi bruker og deler videre CC0-dedikerte verk som er delt utenfor Norge, navngir vi
-                            opphavspersonen i tråd med norsk lov, og merker “Public Domain Dedication”. Typisk gjelder dette bilder fra Pixabay.</p>
+                            opphavspersonen i tråd med norsk lov, og merker “Public Domain Dedication”.</p>
                     </div>
                 </div>
                 <div class="row w-row">


### PR DESCRIPTION
Pixabay har endra lisensiering.