### PR TITLE
Update bruk-av-lisenser.html

### DIFF
--- a/bruk-av-lisenser.html
+++ b/bruk-av-lisenser.html
@@ -189,7 +189,7 @@
                     <h2>Når et verk inneholder andre verk (multilisensiering)</h2>
                     <p>Ofte bruker eller lager vi verk som inneholder mange andre verk, for eksempel en presentasjon eller en video. Da skal de enkelte verkene merkes, f.eks. alle bildene hver for seg. I noen tilfeller kan slik merking oppsummeres, men det
                         skal ikke være tvil om hvilke verk merkingen gjelder. </p>
-                    <p>Det samlede verket kan ha åpnere lisens enn delkomponentene. En video kan lisensieres med BY-SA selv om den inneholder musikk med BY-NC-lisens. Men hvis noen vil gjenbruke verket, må de fjerne musikken for å benytte verket kommersielt.</p>
+                    <p>Det samlede verket kan ha åpnere lisens enn delkomponentene. En artikkel kan lisensieres med BY-SA selv om den inneholder et bilde med BY-NC-lisens. Men hvis noen vil gjenbruke verket, må de fjerne musikken for å benytte verket kommersielt.</p>
                     <h3>Sjekkliste</h3>
                     <ol>
                         <li>‍Er opphavsperson/rettighetshaver entydig identifisert?</li>

--- a/bruk-av-lisenser.html
+++ b/bruk-av-lisenser.html
@@ -189,7 +189,7 @@
                     <h2>Når et verk inneholder andre verk (multilisensiering)</h2>
                     <p>Ofte bruker eller lager vi verk som inneholder mange andre verk, for eksempel en presentasjon eller en video. Da skal de enkelte verkene merkes, f.eks. alle bildene hver for seg. I noen tilfeller kan slik merking oppsummeres, men det
                         skal ikke være tvil om hvilke verk merkingen gjelder. </p>
-                    <p>Det samlede verket kan ha åpnere lisens enn delkomponentene. En artikkel kan lisensieres med BY-SA selv om den inneholder et bilde med BY-NC-lisens. Men hvis noen vil gjenbruke verket, må de fjerne musikken for å benytte verket kommersielt.</p>
+                    <p>Det samlede verket kan ha åpnere lisens enn delkomponentene. En artikkel kan lisensieres med BY-SA selv om den inneholder et bilde med BY-NC-lisens. Men hvis noen vil gjenbruke verket, må de fjerne bildet for å benytte verket kommersielt.</p>
                     <h3>Sjekkliste</h3>
                     <ol>
                         <li>‍Er opphavsperson/rettighetshaver entydig identifisert?</li>


### PR DESCRIPTION
 Video skal alltid regnes som en bearbeidelse (ikke samleverk) og lisensen må derfor dekke alt innholdet. En artikkel derimot kan ha åpen lisens selv om deler av innholdet er på strengere lisens. Bytt derfor:
 En video kan lisensieres med BY-SA selv om den inneholder musikk med BY-NC-lisens.
Med
En artikkel kan lisensieres med BY-SA selv om den inneholder et bilde med BY-NC-lisens.